### PR TITLE
Follow-up to pull #1 - move jQuery to `devDependencies` for clarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.10",
   "description": "Show a widely configurable notice for European cookie law",
   "main": "gruntfile.js",
-  "browser": "dist/cookie-notice.js",
+  "browser": "dist/cookie.notice.js",
   "scripts": {
-    "test": "./node_modules/.bin/grunt test"
+    "test": "grunt test"
   },
   "keywords": [
     "GDPR",
@@ -23,10 +23,8 @@
     "grunt-contrib-qunit": "^2.0.0",
     "grunt-contrib-uglify": "^3.3.0",
     "grunt-strip-code": "^1.0.6",
-    "phantomjs-prebuilt": "^2.1.16"
-  },
-  "peerDependencies": {
     "jquery": "^3.3.1",
+    "phantomjs-prebuilt": "^2.1.16",
     "qunit": "^2.6.1"
   },
   "repository": {

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>QUnit Example</title>
+    <title>QUnit tests — cookie-notice</title>
 
-    <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.6.1.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 
 </head>
 <body>
+
 <div id="qunit"></div>
 <div id="qunit-fixture"></div>
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
-<script src="https://code.jquery.com/qunit/qunit-2.6.1.js"></script>
+
+<script src="../node_modules/jquery/dist/jquery.slim.js"></script>
+<script src="../node_modules/qunit/qunit/qunit.js"></script>
 <script src="tests.js"></script>
 
 <script src="../src/cookie.notice.js"></script>


### PR DESCRIPTION
Hi,

As mentioned, here is a fix for pull #1 (Travis-CI automation) ...

 * Also move QUnit from `peer..` to `devDependencies` ~ in `package.json`.

Note, npm adds the `./node_modules/.bin/` directory to the Node-path, before running, so `scripts` in package.json can just use, e.g. `"grunt test"`.

Nick