### PR TITLE
Add accessibility testing and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ cache:
 
 # install: npm install
 
-script: grunt
+script: npm test
 
 after_script:
-- ls -al dist/
-- pgrep -lf '(live-server|phantom)'
+  - ls -al dist/
+  - pgrep -lf '(live-server|phantom)'
 
 deploy:
   provider: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+
+# CookieNotice changelog
+
+← [README][]
+
+Version History
+
+## Version 1.1.12
+
+ * _Date:  approx. 4-6 June 2018_;
+ * Add accessibility testing via [grunt-rsids-pa11y][] and [pa11y][], WCAG 2.0 AA, pull #6;
+ * Accessibility fixes — colour contrast, button role, link target, link underline;
+ * Accessibility fixes — express CSS font-size in `em` or `rem`, not `px`;
+ * Add configuration option — `learnMoreLinkTarget` (default: '');
+ * Edit the language used in the English translation;
+ * Fix `browser` and `repository` fields in `package.json`;
+ * Add `files` and `bugs` fields to `package.json`;
+ * Add `engines` and `contributors` fields to `package.json`;
+ * Add `live-server` to `peerDependencies` in `package.json`;
+ * Remove Nick's email address from `README` & `bower.json` (!)
+
+## Version 1.1.11
+
+ * _Date:  30 May 2018_;
+ * Add support for `data-cookie-notice` attribute on `<script>`, pull #5, issue [#4][];
+ * Document `data-` attribute in README;
+ * Document _unpkg_ CDN in README;
+
+## Version 1.1.10
+
+ * _Date:  29 May 2018_;
+ * Move jQuery to `devDependencies` for clarity, pull #2;
+ * Point `tests/index.html` to local copies of jQuery and QUnit;
+
+## Version 1.1.9
+
+ * _Date:  25 May 2018_;
+ * Add Travis-CI testing to the project, pull #1;
+ * Update test dependencies —
+   jQuery from 2.x → 3.x; QUnit from 1.x → 2.x;
+ * Add SVG badges for Travis-CI, NPMJS.com, etc. to `README.md`;
+
+## Version 1.1.8
+
+ * _Date:  25 May 2018_;
+
+## Version 1.1.7
+
+ * _Date:  25 April 2018_;
+
+...
+
+## Version 1.1.0
+
+ * _Date:  24 April 2018_;
+ * First release on NPMJS;
+
+---
+
+← [README][]
+
+[readme]: https://github.com/AOEpeople/cookie-notice#readme
+[#4]: https://github.com/AOEpeople/cookie-notice/issues/4
+[a11y-fail]: https://travis-ci.org/nfreear/cookie-notice/jobs/387344672#L1217-L1235
+[grunt-rsids-pa11y]: https://www.npmjs.com/package/grunt-rsids-pa11y
+[pa11y]: http://pa11y.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Version History
  * Add accessibility testing via [grunt-rsids-pa11y][] and [pa11y][], WCAG 2.0 AA, pull #6;
  * Accessibility fixes — colour contrast, button role, link target, link underline;
  * Accessibility fixes — express CSS font-size in `em` or `rem`, not `px`;
- * Add configuration option — `learnMoreLinkTarget` (default: '');
+ * Add configuration option — `linkTarget` (default: '');
  * Edit the language used in the English translation;
  * Fix `browser` and `repository` fields in `package.json`;
  * Add `files` and `bugs` fields to `package.json`;
@@ -30,7 +30,7 @@ Version History
 
  * _Date:  29 May 2018_;
  * Move jQuery to `devDependencies` for clarity, pull #2;
- * Point `tests/index.html` to local copies of jQuery and QUnit;
+ * Point `tests/index.html` to local copies of jQuery and QUnit (was CDN);
 
 ## Version 1.1.9
 
@@ -53,13 +53,21 @@ Version History
 ## Version 1.1.0
 
  * _Date:  24 April 2018_;
- * First release on NPMJS;
+ * First release on [npm][];
+
+## Version 1.0.0
+
+ * _Date:  20 May 2015_;
+ * Release by:  [@micc83][];
+ * (Not on [npm][])
 
 ---
 
 ← [README][]
 
 [readme]: https://github.com/AOEpeople/cookie-notice#readme
+[npm]: https://www.npmjs.com/package/cookie-notice
+[@micc83]: https://github.com/micc83/cookie-notice-js "Alessandro Benoit"
 [#4]: https://github.com/AOEpeople/cookie-notice/issues/4
 [a11y-fail]: https://travis-ci.org/nfreear/cookie-notice/jobs/387344672#L1217-L1235
 [grunt-rsids-pa11y]: https://www.npmjs.com/package/grunt-rsids-pa11y

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 # CookieNotice
 
-**CookieNoticeJS** is a very simple and small *(→ 2 kB gzip)* vanilla JS script with multi language support for GDPR/DSGVO‎ transparency and
+**CookieNoticeJS** is a very simple and small *(→ 2 kB gzip)* vanilla JS script with multi language support for [GDPR][]/[DSGVO][]‎ transparency and
 notification purposes that provides an easy way to show a cookie notice on your website.
 
 <img src="https://i.imgur.com/koDf1h0.png" alt="FetchBot" align="center"/>
 
-**Available via npm**
+**Available via [npm][]**
 
 ```shell
 npm install cookie-notice
+npm test
 ```
 
 
@@ -100,6 +101,9 @@ For the most of you including the script should be enough but **CookieNoticeJS**
        // the learnMoreLink color (default='#009fdd')
        'linkColor': '#f00',
 
+       // The target of the learn more link (default='', or '_blank')
+       'linkTarget': '',
+
        // Print debug output to the console (default=false)
        'debug': false
     });
@@ -144,7 +148,10 @@ License: [MIT][]
 [build]: https://github.com/AOEpeople/cookie-notice/tree/master/dist
 [size-icon]: https://img.shields.io/github/size/AOEpeople/cookie-notice/dist/cookie.notice.min.js.svg
     "Size of built Javascript, kilo-bytes (kB) – on GitHub"
-[unpkg]: http://unpkg.com/ "unpkg is a fast, global content delivery network (CDN) for everything on npm."
+[unpkg]: https://unpkg.com/ "unpkg is a fast, global content delivery network (CDN) for everything on npm."
 [browse]: https://unpkg.com/cookie-notice@^1/ "Browse cookie-notice on unpkg"
+
+[DSGVO]: https://de.wikipedia.org/wiki/Datenschutz-Grundverordnung "Datenschutz-Grundverordnung (DSGVO)"
+[GDPR]: https://en.wikipedia.org/wiki/General_Data_Protection_Regulation "General Data Protection Regulation (GDPR)"
 
 [End]: //.

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ For example:
 Alessandro Benoit
 
 #### Contributors
-[Bernhard Behrendt](mailto:bernhard.behrendt@aoe.com) [@AOEpeople](https://github.com/AOEpeople)
-[Nick Freear](mailto:nfreear@yahoo.co.uk) [IET at the OU](https://github.com/IET-OU)
+[Bernhard Behrendt](mailto:bernhard.behrendt@aoe.com) [@AOEpeople](https://github.com/AOEpeople),
+[Nick Freear](https://github.com/nfreear) [IET at the OU](https://github.com/IET-OU)
 
 ### License
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "authors": [
     "Alessandro Benoit <micc83@gmail.com>",
     "Bernhard Behrendt <bernhard.behrendt@aoe.com>",
-    "Nick Freear<nfreear@yahoo.co.uk>"
+    "Nick Freear"
   ],
   "description": "A very simple script to easily add the European Cookie Law disclaimer to any website.",
   "keywords": [
@@ -22,6 +22,7 @@
     ".gitignore",
     ".gitattributes",
     ".editorconfig",
+    ".travis.yml",
     "index.html",
     "node_modules",
     "bower_components",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -24,11 +24,11 @@ module.exports = function (grunt) {
             test: {
                 options: { // Task-specific options go here.
                     // screenCapture: './_pa11y-screen-capture.png',
-                    standard: 'WCAG2AAA',
+                    standard: 'WCAG2AA', // Or 'WCAG2AAA'
                     timeout: 5000,
                     wait: 500,
-                    rootElement: '#cookieNotice',
-                    verifyPage: 'id="cookieNotice"'
+                    rootElement: 'body', // Was: '#cookieNotice',
+                    verifyPage: 'id="cookieNotice"' // Not supported?
                 },
                 url: [ 'http://localhost:8000/tests/data.html' ]
                 //, file: [ 'array of files, globbing permitted' ]

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,6 +20,20 @@ module.exports = function (grunt) {
                 }
             }
         },
+        rsids_pa11y: { // Accessibility testing, via ~ http://pa11y.org/
+            test: {
+                options: { // Task-specific options go here.
+                    // screenCapture: './_pa11y-screen-capture.png',
+                    standard: 'WCAG2AAA',
+                    timeout: 5000,
+                    wait: 500,
+                    rootElement: '#cookieNotice',
+                    verifyPage: 'id="cookieNotice"'
+                },
+                url: [ 'http://localhost:8000/tests/data.html' ]
+                //, file: [ 'array of files, globbing permitted' ]
+            }
+        },
         strip_code: {
 
             src: {
@@ -45,9 +59,10 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-strip-code');
+    grunt.loadNpmTasks('grunt-rsids-pa11y');
 
     // Default task(s).
-    grunt.registerTask('default', ['connect', 'qunit', 'strip_code', 'uglify']);
-    grunt.registerTask('test', ['connect', 'qunit']);
+    grunt.registerTask('default', [ 'test', 'strip_code', 'uglify' ]);
+    grunt.registerTask('test', [ 'connect', 'qunit', 'rsids_pa11y' ]);
 
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
   ],
   "author": "Alessandro Benoit, Bernhard Behrendt",
   "contributors": [
-    { "name": "Bernhard Behrendt" },
-    { "name": "Nick Freear" }
+    {
+      "name": "Bernhard Behrendt"
+    },
+    {
+      "name": "Nick Freear"
+    }
   ],
   "license": "MIT",
   "devDependencies": {
@@ -26,13 +30,14 @@
     "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-qunit": "^2.0.0",
     "grunt-contrib-uglify": "^3.3.0",
+    "grunt-rsids-pa11y": "^0.3.4",
     "grunt-strip-code": "^1.0.6",
     "jquery": "^3.3.1",
     "phantomjs-prebuilt": "^2.1.16",
     "qunit": "^2.6.1"
   },
-  "engines" : {
-    "node" : ">=6.0"
+  "engines": {
+    "node": ">=6.0"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "gruntfile.js",
   "browser": "dist/cookie.notice.js",
   "scripts": {
+    "start": "live-server --port=9001",
     "test": "grunt"
   },
   "keywords": [
@@ -35,6 +36,9 @@
     "jquery": "^3.3.1",
     "phantomjs-prebuilt": "^2.1.16",
     "qunit": "^2.6.1"
+  },
+  "peerDependencies": {
+    "live-server": "^1.2.0"
   },
   "engines": {
     "node": ">=6.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.11",
   "description": "Show a widely configurable notice for European cookie law",
   "main": "gruntfile.js",
-  "browser": "dist/cookie-notice.js",
+  "browser": "dist/cookie.notice.js",
   "scripts": {
     "test": "grunt"
   },
@@ -15,6 +15,10 @@
     "vanilla"
   ],
   "author": "Alessandro Benoit, Bernhard Behrendt",
+  "contributors": [
+    { "name": "Bernhard Behrendt" },
+    { "name": "Nick Freear" }
+  ],
   "license": "MIT",
   "devDependencies": {
     "grunt": "^1.0.2",
@@ -27,8 +31,16 @@
     "phantomjs-prebuilt": "^2.1.16",
     "qunit": "^2.6.1"
   },
+  "engines" : {
+    "node" : ">=6.0"
+  },
+  "files": [
+    "dist/",
+    "src/"
+  ],
+  "bugs": "https://github.com/AOEpeople/cookie-notice/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AOEpeople/cookie-notice-js"
+    "url": "https://github.com/AOEpeople/cookie-notice"
   }
 }

--- a/src/cookie.notice.js
+++ b/src/cookie.notice.js
@@ -19,7 +19,7 @@
     var defaults = {
         'messageLocales': {
             'it': 'Utilizziamo i cookie per essere sicuri che tu possa avere la migliore esperienza sul nostro sito. Se continui ad utilizzare questo sito assumiamo che tu ne sia felice.',
-            'en': 'We use cookies to make sure you can have the best experience on our website. If you continue to use this site we assume that you will be happy with it.',
+            'en': 'We use cookies to ensure that you have the best experience on our website. If you continue to use this site we assume that you accept this.',
             'de': 'Wir verwenden Cookies um sicherzustellen dass Sie das beste Erlebnis auf unserer Website haben.',
             'fr': 'Nous utilisons des cookies afin d\'être sûr que vous pouvez avoir la meilleure expérience sur notre site. Si vous continuez à utiliser ce site, nous supposons que vous acceptez.'
         },
@@ -38,7 +38,7 @@
         },
 
         'buttonLocales': {
-            'en': 'Ok'
+            'en': 'OK'
         },
 
         'expiresIn': 30,

--- a/src/cookie.notice.js
+++ b/src/cookie.notice.js
@@ -42,7 +42,7 @@
         },
 
         'expiresIn': 30,
-        'buttonBgColor': '#983c00', // Accessibility contrast fix (Was: '#d35400').
+        'buttonBgColor': '#ca5000', // Accessibility contrast fix (Was: '#d35400') (WCAG2AAA: '#983c00').
         'buttonTextColor': '#fff',
         'noticeBgColor': '#000',
         'noticeTextColor': '#fff',
@@ -166,7 +166,7 @@
 
         var notice = document.createElement('div'),
             noticeStyle = notice.style,
-            lineHeight = 28,
+            lineHeight = 2, // Was: 28 (px).
             paddingBottomTop = 10,
             fontSize = lineHeight / 2.333,
             noticeHeight = lineHeight + paddingBottomTop * 2;
@@ -198,8 +198,8 @@
         noticeStyle["z-index"] = '999';
         noticeStyle.padding = paddingBottomTop + 'px 5px';
         noticeStyle["text-align"] = 'center';
-        noticeStyle["font-size"] = fontSize + "px";
-        noticeStyle["line-height"] = lineHeight + "px";
+        noticeStyle["font-size"] = fontSize + 'rem'; // Was: 'px'.
+        noticeStyle["line-height"] = lineHeight + 'rem'; // Was: 'px'.
         noticeStyle.fontFamily = 'Helvetica neue, Helvetica, sans-serif';
 
 

--- a/src/cookie.notice.js
+++ b/src/cookie.notice.js
@@ -42,11 +42,12 @@
         },
 
         'expiresIn': 30,
-        'buttonBgColor': '#d35400',
+        'buttonBgColor': '#983c00', // Accessibility contrast fix (Was: '#d35400').
         'buttonTextColor': '#fff',
         'noticeBgColor': '#000',
         'noticeTextColor': '#fff',
         'linkColor': '#009fdd',
+        'linkTarget': '', // Accessibility fix (Was: '_blank').
         'debug': false
     };
 
@@ -107,7 +108,7 @@
         if (params.learnMoreLinkEnabled) {
             var learnMoreLinkText = getStringForCurrentLocale(params.learnMoreLinkText);
 
-            learnMoreLink = createLearnMoreLink(learnMoreLinkText, params.learnMoreLinkHref, params.linkColor);
+            learnMoreLink = createLearnMoreLink(learnMoreLinkText, params.learnMoreLinkHref, params.linkTarget, params.linkColor);
         }
 
         // Get current locale for button text
@@ -221,6 +222,7 @@
         dismissButton.href = '#';
         dismissButton.innerHTML = message;
 
+        dismissButton.setAttribute('role', 'button'); // Accessibility fix.
         dismissButton.className = 'confirm';
 
         dismissButton.setAttribute('data-test-action', 'dismiss-cookie-notice');
@@ -246,19 +248,19 @@
      * @param linkColor
      * @returns {HTMLElement}
      */
-    function createLearnMoreLink(learnMoreLinkText, learnMoreLinkHref, linkColor) {
+    function createLearnMoreLink(learnMoreLinkText, learnMoreLinkHref, linkTarget, linkColor) {
 
         var learnMoreLink = document.createElement('a'),
             learnMoreLinkStyle = learnMoreLink.style;
 
         learnMoreLink.href = learnMoreLinkHref;
         learnMoreLink.textContent = learnMoreLinkText;
-        learnMoreLink.target = '_blank';
+        learnMoreLink.target = linkTarget;
         learnMoreLink.className = 'learn-more';
         learnMoreLink.setAttribute('data-test-action', 'learn-more-link');
 
         learnMoreLinkStyle.color = linkColor;
-        learnMoreLinkStyle['text-decoration'] = 'none';
+        learnMoreLinkStyle['text-decoration'] = 'underline'; // Accessibility fix (Was: 'none').
         learnMoreLinkStyle.display = 'inline';
 
         return learnMoreLink;

--- a/tests/data.html
+++ b/tests/data.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title> data-cookie-notice </title>
+</head>
+<body>
+
+<h1> data-cookie-notice </h1>
+
+
+<script data-cookie-notice=
+'{ "learnMoreLinkEnabled": true, "learnMoreLinkHref": "/privacy.html", "X-cookieNoticePosition": "top", "debug": true }'
+  data-CDN-src="https://unpkg.com/cookie-notice@^1/dist/cookie.notice.min.js"
+  src="../src/cookie.notice.js"
+></script>
+
+</body>
+</html>


### PR DESCRIPTION
Hi @BernhardBehrendt,

I've added automated accessibility testing with `grunt-rsids-pa11y`.

There are some subtle accessibility fixes to the cookie-notice user-interface:

 * Slightly darker red for the button (fixes colour contrast);
 * A `role=button` attribute for the button ([WAI-ARIA][]);
 * Underline for the "learn more" link (non-colour based link indication);
 * The "learn more" link now opens in the same window by default (otherwise, we'd need to add "_opens in new window_" or similar to the link-text);
 * There is a new `linkTarget` configuration option, so developers can set `target=_blank`;

Full details of the changes are in the new [Changelog][].

Note, these changes may be enough to justify a `1.2.0` release, instead of a `1.1.12` ([semver](https://semver.org)) -- your call!

I think its important to get accessibility right, as we're providing a third-party user-interface component to developers, and saying "_use this_"!

(_Also, I hope you don't mind - I removed my email address from the README and bower JSON._)

I hope this helps.

Best wishes,


Nick

[changelog]: https://github.com/nfreear/cookie-notice/blob/nfreear/accessibility-etc/CHANGELOG.md
[wai-aria]: https://www.w3.org/TR/wai-aria-1.1/